### PR TITLE
Allow the user to create X amount of users.

### DIFF
--- a/03-create-users.sh
+++ b/03-create-users.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 
 #
-#	12 is pretty optimal amount
+#	12 is pretty insane amount amount and requires ~18GB ram, but for users who are too lazy to add a number at the end, let's just use the previous as default
 #
 
+$max=12
 if ! [ -e "/opt/steamapps" ]; then
 	echo "Can't find steamapps folder."
 	echo "Please, run scripts in the right order."
@@ -12,7 +13,7 @@ fi
 
 read -p "Press ENTER to continue"
 
-for i in {1..12}
+for i in $(seq 1 $max)
 do
 	echo "Creating user catbot-$i"
 	sudo useradd -m catbot-$i

--- a/README.md
+++ b/README.md
@@ -10,14 +10,14 @@
 6. `./01-usergroup.sh`
 7. You have to log out (or restart the PC)
 8. `./02-steamapps.sh "/path/to/steamapps"` (you got path in step 2)
-9. `./03-create-12-users.sh`
+9. `./03-create-users.sh 4` (replace `4` with amount of accounts you want to create, 12 by default)
 10. `./04-locate-cathook.sh "/path/to/cathook"` (step 3)
 11. Run scripts `./05-get-ipc-server.sh`, `./06-rebuild-ipc-server.sh`, `./07-build-textmode.sh`
 12. Choose the amount of bots you will run, it's better to start with something like 1 (to test) or 3. My i5 3570k @ 3.8GHz and 16GB RAM could run 9 cat-bots.
 13. `./08-recommended-settings.sh` - this script will copy chatspam (`botspam` file) and recommended config to your Team Fortress 2 installation
 14. `./09-start-ipc-server.sh`
 15. You have to open new terminal window. Do not close the IPC server, you need it to see bots' status
-16. `./10-start-steams.sh 4` (replace `4` with amount of bots you want to start)
+16. `./10-start-steams.sh 4` (replace `4` with amount of bots you want to start, 6 by default)
 17. You have to accept Steam's license terms, wait for it to install, etc.
 18. Create Steam accounts (or log in) in these Steam windows
 19. You have to launch Team Fortress 2, open Casual matchmaking menu and **select only those maps for which you have walkbot paths installed (these path files must be named `default`). Bot abandons the game if there is no default path for map.**

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 18. Create Steam accounts (or log in) in these Steam windows
 19. You have to launch Team Fortress 2, open Casual matchmaking menu and **select only those maps for which you have walkbot paths installed (these path files must be named `default`). Bot abandons the game if there is no default path for map.**
 20. Click "Save" button above map selection menu. You can close TF2 now.
-21. `./11-start-games.sh 4` - again, replace `4` with number of bots
+21. `./11-start-games.sh 4` (replace `4` with how many intances of TF2 you want to run, 6 by default)
 22. Wait at least 30 seconds (or a minute)
 23. `./12-inject-cathook.sh`
 24. Bots should work now, check IPC server console to see their status.


### PR DESCRIPTION
12 is still the default number. For somebody who doesn't care about how many user they have on their computer, it's there by default. This just lets the user create more or less bots depending on a single number.