### PR TITLE
Fixed 03-create-users.sh

### DIFF
--- a/03-create-users.sh
+++ b/03-create-users.sh
@@ -4,7 +4,7 @@
 #	12 is pretty insane amount amount and requires ~18GB ram, but for users who are too lazy to add a number at the end, let's just use the previous as default
 #
 
-$max=12
+max=12
 
 if [ "$#" == 1 ]; then
 	max=$1


### PR DESCRIPTION
```./03-create-users.sh: line 7: =12: command not found```

I accidentally'd a $ somehow. That's not suppose to be there.