### PR TITLE
Avoid VAC entropic heuristic detection on usernames by generating lower entropy usernames

### DIFF
--- a/00-generate-random-username.sh
+++ b/00-generate-random-username.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 #
-# Script generates random 16-char length string that will be used for usernames
+# Script generates random 6-char length string that will be used for usernames
 #
 
-name=$(cat /dev/urandom | tr -dc 'a-z0-9' | fold -w 16 | head -n 1)
+name=$(cat /dev/urandom | tr -dc 'a-z' | fold -w 6 | head -n 1)
 echo $name > kisak


### PR DESCRIPTION
Hi, I'm a cryptographic engineer and I saw the catbot name issue on Hacker News.

When I saw that random names were implemented, I looked at the entropy content of each generated username.

At 16 random chars (`a-z0-9`), the Shannon entropy average per 1000 usernames is 3.6146. This is quite a high number and immediately renders catbot users vulnerable to Steam VAC heuristic detection via entropy calculations.

Entropy heuristics are common in malware and anti-cheat software. The current solution used increases the precision of VAC detection by affirming that catbot users have high entropic usernames on their system. If left unchanged, this could lead to becoming a high value precision and recall heuristic upon Catbot.

The following PR solves this quite simply by lowering the average Shannon entropy measurement on usernames from 3.6146 per 1000 to 2.4097 per 1000. This number could be improved more probably, but I would leave that up to maintainer discretion.

I used the following Python code to calculate the Shannon entropy level:
```
def entropy(string):
    prob = [ float(string.count(c)) / len(string) for c in dict.fromkeys(list(string)) ]
    entropy = - sum([ p * math.log(p) / math.log(2.0) for p in prob ])
    return entropy
```

From there I took measurements of 1000  6-char and 16-char usernames. I found the average username to have a Shannon entropy measurement of 2.5256. I found this by using [this wordlist](https://github.com/jeanphorn/wordlist/blob/master/usernames.txt) and calculating the average.

# In conclusion:

I have determined that it would be in catbot's best interest to lower the randomly generated username from 16 chars to 6 chars and reduce the char space to only `a-z`.

For further development, it would be ideal to get these randomly generated usernames as close as possible to a  Shannon entropy measurement of 2.5 per 1000.